### PR TITLE
Increase PermGen for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ jdk: oraclejdk7
 
 script:
   - ./gradlew --stacktrace clean build
+
+env:
+- GRADLE_OPTS="-Xmx1024m -XX:MaxPermSize=1024m"


### PR DESCRIPTION
Fixing out of memory error on Travis builds. 

```
java.lang.OutOfMemoryError: PermGen space
```
