### PR TITLE
Multiple code improvements - squid:S1118, squid:ClassVariableVisibilityCheck, squid:S1213, squid:S1066, squid:S2184, squid:S00115

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/entity/Problem.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/entity/Problem.java
@@ -20,18 +20,18 @@ public class Problem {
     public static final int STATUS_IN_PROGRESS = 0;
     public static final int STATUS_DONE = 1;
 
-    public int id;
-    public String title;
-    public String description;
+    private int id;
+    private String title;
+    private String description;
 
-    public String address;
+    private String address;
     @StatusCode
-    public int statusCode;
-    public Date updatedAt;
+    private int statusCode;
+    private Date updatedAt;
 
-    public double lat, lng;
+    private double lat, lng;
 
-    public String thumbUrl;
+    private String thumbUrl;
 
     public void applyReportStatusLabel(@NonNull TextView reportLabelTextView) {
         switch (statusCode) {
@@ -73,6 +73,46 @@ public class Problem {
 
     public LatLng getLatLng() {
         return new LatLng(lat, lng);
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public void setLat(double lat) {
+        this.lat = lat;
+    }
+
+    public void setLng(double lng) {
+        this.lng = lng;
+    }
+
+    public void setThumbUrl(String thumbUrl) {
+        this.thumbUrl = thumbUrl;
     }
 
     public String getRelativeUpdatedAt() {

--- a/app/src/main/java/lt/vilnius/tvarkau/factory/DummyProblems.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/factory/DummyProblems.java
@@ -26,6 +26,8 @@ public class DummyProblems {
             "Konstitucijos pr. 3"
     };
 
+    private DummyProblems() {}
+
     public static List<Problem> getProblems() {
         if (problems == null) problems = createProblems();
         return problems;
@@ -39,22 +41,22 @@ public class DummyProblems {
         for (int i = 0; i < COUNT; i++) {
             Problem problem = new Problem();
 
-            problem.id = i;
-            problem.title = "Gatvių priežiūra ir tvarkymas";
-            problem.description = "Klinikų g. jau du mėnesiai nenaudojama pilnai pilnai įrengta automobilių parkavimo....";
+            problem.setId(i);
+            problem.setTitle("Gatvių priežiūra ir tvarkymas");
+            problem.setDescription("Klinikų g. jau du mėnesiai nenaudojama pilnai pilnai įrengta automobilių parkavimo....");
 
             if (Math.random() < 0.5) {
-                problem.statusCode = Problem.STATUS_IN_PROGRESS;
+                problem.setStatusCode(Problem.STATUS_IN_PROGRESS);
             } else {
-                problem.statusCode = Problem.STATUS_DONE;
+                problem.setStatusCode(Problem.STATUS_DONE);
             }
-            problem.updatedAt = new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis((int) (Math.random() * 20) + 5));
+            problem.setUpdatedAt(new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis((int) (Math.random() * 20) + 5L)));
 
-            problem.lat = 54.5 + 0.4 * Math.random();
-            problem.lng = 25.1 + 0.4 * Math.random();
+            problem.setLat(54.5 + 0.4 * Math.random());
+            problem.setLng(25.1 + 0.4 * Math.random());
 
-            problem.thumbUrl = thumbsUrls[random.nextInt(thumbsUrls.length)];
-            problem.address = adresses[random.nextInt(adresses.length)];
+            problem.setThumbUrl(thumbsUrls[random.nextInt(thumbsUrls.length)]);
+            problem.setAddress(adresses[random.nextInt(adresses.length)]);
 
             problems.add(problem);
         }

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseMapFragment.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseMapFragment.java
@@ -103,10 +103,8 @@ public abstract class BaseMapFragment extends SupportMapFragment
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (requestCode == GPS_PERMISSION_REQUEST_CODE) {
-            if (PermissionUtils.isAllPermissionsGranted(getActivity(), MAP_PERMISSIONS)) {
-                googleMap.setMyLocationEnabled(true);
-            }
+        if (requestCode == GPS_PERMISSION_REQUEST_CODE && PermissionUtils.isAllPermissionsGranted(getActivity(), MAP_PERMISSIONS)) {
+            googleMap.setMyLocationEnabled(true);
         }
     }
 

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/MyProfileFragment.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/MyProfileFragment.java
@@ -32,10 +32,6 @@ import static butterknife.OnTextChanged.Callback.AFTER_TEXT_CHANGED;
 
 public class MyProfileFragment extends Fragment {
 
-    public static MyProfileFragment getInstance() {
-        return new MyProfileFragment();
-    }
-
     private SharedPrefsManager prefsManager;
 
     @Bind(R.id.profile_name)
@@ -49,6 +45,10 @@ public class MyProfileFragment extends Fragment {
 
 
     public MyProfileFragment() {}
+
+    public static MyProfileFragment getInstance() {
+        return new MyProfileFragment();
+    }
 
     @Nullable
     @Override

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/ProblemsListFragment.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/ProblemsListFragment.java
@@ -19,11 +19,11 @@ import lt.vilnius.tvarkau.views.adapters.ProblemsListAdapter;
  */
 public class ProblemsListFragment extends Fragment {
 
+    @Bind(R.id.problem_list) RecyclerView recyclerView;
+
     public static ProblemsListFragment getInstance() {
         return new ProblemsListFragment();
     }
-
-    @Bind(R.id.problem_list) RecyclerView recyclerView;
 
 
     @Nullable

--- a/app/src/main/java/lt/vilnius/tvarkau/network/TokenAuthenticator.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/network/TokenAuthenticator.java
@@ -25,7 +25,7 @@ import okhttp3.Route;
 @Singleton
 public class TokenAuthenticator implements Authenticator {
 
-    protected static final int maxRetries = 3;
+    protected static final int MAX_RETRIES = 3;
 
     @Inject
     Lazy<UserService> userService;
@@ -33,7 +33,7 @@ public class TokenAuthenticator implements Authenticator {
     @Override
     public Request authenticate(Route route, Response response) throws IOException {
         // Give up after unsuccessful retries
-        if (responseCount(response) >= maxRetries) {
+        if (responseCount(response) >= MAX_RETRIES) {
             return null;
         }
 

--- a/app/src/main/java/lt/vilnius/tvarkau/utils/Authentication.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/utils/Authentication.java
@@ -9,6 +9,8 @@ public class Authentication {
 
     protected static Token token;
 
+    private Authentication() {}
+
     public static Token getToken() {
         return token;
     }

--- a/app/src/main/java/lt/vilnius/tvarkau/utils/FileUtils.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/utils/FileUtils.java
@@ -12,6 +12,8 @@ import java.util.Date;
  */
 public class FileUtils {
 
+    private FileUtils() {}
+
     public static File createTempImageFile() throws IOException {
         // Create an image file name
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());

--- a/app/src/main/java/lt/vilnius/tvarkau/utils/PermissionUtils.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/utils/PermissionUtils.java
@@ -11,6 +11,8 @@ import android.util.Log;
  */
 public class PermissionUtils {
 
+    private PermissionUtils() {}
+
     public static boolean isAllPermissionsGranted(@NonNull Activity activity,
                                                   @NonNull String[] permissions) {
         for (String permission : permissions) {

--- a/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemImagesPagerAdapter.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemImagesPagerAdapter.java
@@ -18,6 +18,11 @@ public abstract class ProblemImagesPagerAdapter<T> extends PagerAdapter {
     private LayoutInflater mLayoutInflater;
     private T[] mResources;
 
+    public ProblemImagesPagerAdapter(Context context, T[] images) {
+        mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        mResources = images;
+    }
+
     public static ProblemImagesPagerAdapter<Void> empty(Context context) {
         return new ProblemImagesPagerAdapter<Void>(context, new Void[0]) {
 
@@ -26,11 +31,6 @@ public abstract class ProblemImagesPagerAdapter<T> extends PagerAdapter {
 
             }
         };
-    }
-
-    public ProblemImagesPagerAdapter(Context context, T[] images) {
-        mLayoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        mResources = images;
     }
 
     @Override

--- a/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemsListAdapter.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemsListAdapter.java
@@ -49,10 +49,10 @@ public class ProblemsListAdapter
         Problem item = mValues.get(position);
 
         holder.item = item;
-        holder.titleView.setText(item.title);
-        holder.descriptionView.setText(item.description);
+        holder.titleView.setText(item.getTitle());
+        holder.descriptionView.setText(item.getDescription());
         item.applyReportStatusLabel(holder.statusView);
-        holder.timeView.setText(DateUtils.getRelativeTimeSpanString(item.updatedAt.getTime()));
+        holder.timeView.setText(DateUtils.getRelativeTimeSpanString(item.getUpdatedAt().getTime()));
 
         String thumbUrl = item.getThumbUrl();
 
@@ -66,7 +66,7 @@ public class ProblemsListAdapter
         holder.content.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent intent = ProblemDetailActivity.getStartActivityIntent(activity, holder.item.id);
+                Intent intent = ProblemDetailActivity.getStartActivityIntent(activity, holder.item.getId());
 
                 Bundle bundle = ActivityOptionsCompat.makeScaleUpAnimation(view, 0, 0,
                             view.getWidth(), view.getHeight()).toBundle();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S2184 - Math operands should be cast before assignment.
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
George Kankava
