### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/utils/GlobalConsts.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/utils/GlobalConsts.java
@@ -8,4 +8,6 @@ public class GlobalConsts {
     public final static String TAG_MULTIPLE_PROBLEMS_MAP_FRAGMENT = "multipleProblemsMapFragment";
 
     public final static String KEY_MAP_FRAGMENT= "keyMapFragment";
+
+    private GlobalConsts() {}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 30 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
