### PR TITLE
Compile with Android 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ jdk: oraclejdk8
 
 android:
   components:
-    - android-23
+    - platform-tools
     - tools
-    - build-tools-23.0.3
+    - android-24
+    - build-tools-24.0.2
     - extra
 
 script:
@@ -20,7 +21,7 @@ env:
 
 cache:
   directories:
-    - $HOME/.gradle/caches/2.13
+    - $HOME/.gradle/caches/2.14.1
     - $HOME/.gradle/caches/jars-1
     - $HOME/.gradle/daemon
     - $HOME/.gradle/native

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }
@@ -21,13 +21,13 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.ben-manes.versions'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.2"
 
     defaultConfig {
         applicationId "lt.vilnius.tvarkau"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 6
         versionName "3.0"
         vectorDrawables.useSupportLibrary = true
@@ -65,8 +65,8 @@ repositories {
 
 ext {
     junitVersion = '4.12'
-    supportLibraryVersion = '23.4.0'
-    playServicesVersion = '9.0.2'
+    supportLibraryVersion = '24.2.0'
+    playServicesVersion = '9.4.0'
     butterKnifeVersion = '8.0.1'
     glideVersion = '3.7.0'
     icepickVersion = '3.2.0'
@@ -101,6 +101,7 @@ dependencies {
     compile "com.google.android.gms:play-services-maps:$playServicesVersion"
     compile "com.google.android.gms:play-services-location:$playServicesVersion"
     compile "com.google.android.gms:play-services-auth:$playServicesVersion"
+    compile "com.google.android.gms:play-services-places:$playServicesVersion"
 
     compile "com.google.firebase:firebase-core:$playServicesVersion"
     compile "com.google.firebase:firebase-crash:$playServicesVersion"


### PR DESCRIPTION
- Changed `compileSdkVersion` to `24`;
- Upgraded support and play services libraries;
- Updated Travis build file to support newer version;
