### PR TITLE
Main menu button sizes

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/MainActivity.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/MainActivity.java
@@ -3,12 +3,8 @@ package lt.vilnius.tvarkau;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.ActionBar;
-import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.widget.Toast;
 
-import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import lt.vilnius.tvarkau.utils.GlobalConsts;
@@ -28,9 +24,6 @@ public class MainActivity extends BaseActivity {
     public static final int NEW_ISSUE_REQUEST_CODE = 12;
     public static final String[] MAP_PERMISSIONS = new String[]{ACCESS_FINE_LOCATION};
 
-    @BindView(R.id.toolbar)
-    Toolbar toolbar;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -38,11 +31,6 @@ public class MainActivity extends BaseActivity {
 
         ButterKnife.bind(this);
 
-        setSupportActionBar(toolbar);
-
-        ActionBar actionBar = getSupportActionBar();
-
-        actionBar.setDisplayShowTitleEnabled(false);
     }
 
     protected void startNewActivity(Class<?> cls) {

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -1,102 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
 
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/app_bar"
+    <ImageView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
-
-        <android.support.v7.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:popupTheme="@style/AppTheme.PopupOverlay">
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/colorPrimary"
-                android:contentDescription="@string/app_name"
-                android:scaleType="centerInside"
-                android:src="@drawable/ic_logo_white" />
-        </android.support.v7.widget.Toolbar>
-
-    </android.support.design.widget.AppBarLayout>
+        android:background="@color/colorPrimary"
+        android:contentDescription="@string/app_name"
+        android:padding="8dp"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_logo_white"
+        />
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/content_background"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        >
 
         <android.support.v7.widget.GridLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingLeft="12dp"
-            android:paddingRight="12dp"
-            android:paddingTop="16dp"
+            android:padding="12dp"
             app:columnCount="2"
-            app:useDefaultMargins="true">
+            app:useDefaultMargins="true"
+            >
 
             <TextView
                 android:id="@+id/home_report_problem"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_new_report"
                 android:text="@string/home_report_a_problem"
-                app:layout_columnWeight="1" />
+                />
 
             <TextView
                 android:id="@+id/home_my_problems"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_my_problems"
                 android:text="@string/home_my_problems"
-                app:layout_columnWeight="1" />
+                />
 
             <TextView
                 android:id="@+id/home_list_of_problems"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_list_of_problems"
                 android:text="@string/home_list_of_reports"
-                app:layout_columnWeight="1" />
+                />
 
             <TextView
                 android:id="@+id/home_map_of_problems"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_map_of_problems"
                 android:text="@string/home_map_of_problems"
-                app:layout_columnWeight="1" />
+                />
 
             <TextView
                 android:id="@+id/home_settings"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_settings"
                 android:text="@string/home_settings"
-                app:layout_columnWeight="1" />
+                />
 
             <TextView
                 android:id="@+id/home_about"
                 style="@style/HomeScreenButtonStyle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
                 android:drawableTop="@drawable/home_about"
                 android:text="@string/home_about"
-                app:layout_columnWeight="1" />
-
+                />
         </android.support.v7.widget.GridLayout>
     </ScrollView>
-
-</android.support.design.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/values-h520dp/dimens.xml
+++ b/app/src/main/res/values-h520dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="home_button_size">112dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,7 +4,7 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
 
-    <dimen name="home_button_size">112dp</dimen>
+    <dimen name="home_button_size">80dp</dimen>
 
     <dimen name="problem_status_label_radius">3dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,10 +30,16 @@
         <item name="android:typeface">sans</item>
         <item name="android:gravity">center_horizontal</item>
         <item name="android:layout_gravity">center_horizontal</item>
-        <item name="android:paddingTop">16dp</item>
+        <item name="android:padding">4dp</item>
         <item name="android:drawablePadding">8dp</item>
         <item name="android:textColor">@color/home_button_text_color</item>
         <item name="android:textSize">16sp</item>
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:clipToPadding">false</item>
+        <item name="layout_columnWeight">1</item>
+        <item name="layout_rowWeight">1</item>
+        <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
     <style name="ReportStatusLabel">


### PR DESCRIPTION
Fit menu buttons on smaller screens

For large screens, menu buttons will be the same. 
Reduce menu screen's button sizes for <h520dp screens.
Clean up main_activity layout
Extract repeated style elements for grid layout
Reduce number of views in MainActivity 
Simplify MainActivity layout - i.e. remove action bar related views which were not useful

relates to https://github.com/vilnius/tvarkau-vilniu/issues/82
