### PR TITLE
Upgrade dependencies due to bug in Play services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - platform-tools
     - tools
     - android-25
-    - build-tools-25.0.0
+    - build-tools-25.0.1
     - extra
   licenses:
     - 'android-sdk-preview-license-.+'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ repositories {
 ext {
     junitVersion = '4.12'
     supportLibraryVersion = '25.0.1'
-    playServicesVersion = '10.0.0'
+    playServicesVersion = '10.0.1'
     butterKnifeVersion = '8.4.0'
     glideVersion = '3.7.0'
     icepickVersion = '3.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'com.github.ben-manes.versions'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "lt.vilnius.tvarkau"


### PR DESCRIPTION
As we are preparing for release updating dependencies due to https://developers.google.com/android/guides/releases
Google Play services updated to 10.0.1 This release fixes a missing minSdkVersion value in play-services-location.aar that caused unintended WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE, and READ_PHONE_STATE permissions to be merged into app manifests.