### PR TITLE
Add extra 8dps to view padding

### DIFF
--- a/app/src/main/res/layout/problem_detail.xml
+++ b/app/src/main/res/layout/problem_detail.xml
@@ -54,7 +54,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:paddingBottom="16dp"
+                android:paddingBottom="24dp"
                 android:paddingLeft="24dp"
                 android:paddingRight="24dp">
 


### PR DESCRIPTION
Ref: https://trello.com/c/hdX1WQsF/152-add-extra-8dp-between-id-number-and-location-fields