### PR TITLE
Cleanup libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ android:
     - tools
     - android-25
     - build-tools-25.0.1
+    - extra-android-support
     - extra
   licenses:
     - 'android-sdk-preview-license-.+'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,8 +97,8 @@ ext {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-
-    compile "com.android.support:support-v4:$supportLibraryVersion"
+    
+    compile "com.android.support:support-fragment:$supportLibraryVersion"
     compile "com.android.support:appcompat-v7:$supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
     compile "com.android.support:gridlayout-v7:$supportLibraryVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,9 +131,7 @@ dependencies {
     provided "javax.annotation:jsr250-api:$javaxAnnotationVersion"
 
     compile "fr.avianey.com.viewpagerindicator:library:$viewPagerIndicatorVersion"
-
-    compile "com.github.ParkSangGwon:TedPicker:$tedPickerVersion"
-
+    
     compile "org.greenrobot:eventbus:$eventBusVersion"
 
     compile "com.facebook.stetho:stetho:$stethoVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ ext {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    
+
     compile "com.android.support:support-fragment:$supportLibraryVersion"
     compile "com.android.support:appcompat-v7:$supportLibraryVersion"
     compile "com.android.support:recyclerview-v7:$supportLibraryVersion"
@@ -107,7 +107,6 @@ dependencies {
     compile "com.google.android.gms:play-services-maps:$playServicesVersion"
     compile "com.google.android.gms:play-services-location:$playServicesVersion"
     compile "com.google.android.gms:play-services-places:$playServicesVersion"
-    compile "com.google.android.gms:play-services-auth:$playServicesVersion"
 
     compile "com.google.firebase:firebase-core:$playServicesVersion"
     compile "com.google.firebase:firebase-crash:$playServicesVersion"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,6 +28,7 @@
     <color name="snackbar_action_text">#3bdfff</color>
 
     <color name="black_38">#9E9E9E</color>
+    <color name="black_87">#de000000</color>
     <color name="problem_date">#6d6d6d</color>
     <color name="problem_address">#27aae1</color>
     <color name="link_color">#27aae1</color>


### PR DESCRIPTION
Removed few unused libraries and replaced `com.android.support:support-v4` by  `com.android.support:support-fragment`. 
With this PR .apk size drops about 0.2 MB and method count decreases about 2K.
More statistics about libraries we use
<img width="962" alt="screen shot 2016-12-06 at 22 06 49" src="https://cloud.githubusercontent.com/assets/3719141/20941786/ce3d2606-bc00-11e6-8113-55480420eb17.png">
