### PR TITLE
Incorrect id passed from my problems

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemsListAdapter.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/views/adapters/ProblemsListAdapter.kt
@@ -45,6 +45,7 @@ class ProblemsListAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         if (holder is DataViewHolder) {
             val item = values[position]
+            val problemId = item.problemId
 
             item.applyReportStatusLabel(holder.itemView.problem_list_content_status)
             holder.itemView.problem_list_content_description.text = item.description
@@ -60,9 +61,8 @@ class ProblemsListAdapter(
                 holder.itemView.problem_list_content_thumb.gone()
             }
 
-            holder.itemView.problem_list_content.tag = item.id
             holder.itemView.problem_list_content.setOnClickListener { view ->
-                val intent = ProblemDetailActivity.getStartActivityIntent(activity, view.tag as String)
+                val intent = ProblemDetailActivity.getStartActivityIntent(activity, problemId)
                 val bundle = ActivityOptionsCompat.makeScaleUpAnimation(view, 0, 0,
                         view.width, view.height).toBundle()
 


### PR DESCRIPTION
![screenshot_20161210-120408](https://cloud.githubusercontent.com/assets/3719141/21072702/f7d0a62a-bed3-11e6-8784-596a317dbd77.png)
After clicking on my problem id of empty string has been passed. We should use `problem_id`, not `id` on all problems and my problems.

Interesting: if empty id has been passed server retruns last submitted problem and more than 160 pictures :D