### PR TITLE
Remove empty photo placeholder from adapter and use in layout

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/views/adapters/NewProblemPhotosPagerAdapter.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/views/adapters/NewProblemPhotosPagerAdapter.kt
@@ -14,21 +14,17 @@ import java.io.File
 class NewProblemPhotosPagerAdapter(private val photos: List<File>,
                                    private val listener: OnPhotoClickedListener) : PagerAdapter() {
 
-    override fun getCount(): Int = if (photos.isNotEmpty()) photos.count() else 1
+    override fun getCount(): Int = photos.count()
 
     override fun isViewFromObject(view: View, any: Any): Boolean = view === any
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val layoutInflater = container.context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
-        val itemView: View
-
-        if (photos.isEmpty()) {
-            itemView = layoutInflater.inflate(R.layout.no_image, container, false)
-        } else {
-            itemView = instantiateProblemPhoto(position,
-                    layoutInflater.inflate(R.layout.problem_images_view_pager_item, container, false))
-        }
+        val itemView = instantiateProblemPhoto(
+                position,
+                layoutInflater.inflate(R.layout.problem_images_view_pager_item, container, false)
+        )
 
         container.addView(itemView)
 

--- a/app/src/main/res/layout/fragment_new_report.xml
+++ b/app/src/main/res/layout/fragment_new_report.xml
@@ -20,6 +20,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="272dp">
 
+                <include
+                    layout="@layout/no_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="240dp" />
+
                 <lt.vilnius.tvarkau.views.adapters.HackyViewPager
                     android:id="@+id/problem_images_view_pager"
                     android:layout_width="match_parent"
@@ -40,7 +45,9 @@
                     android:layout_marginBottom="8dp"
                     android:layout_marginEnd="@dimen/activity_horizontal_margin"
                     android:layout_marginRight="@dimen/activity_horizontal_margin"
-                    android:src="@drawable/ic_photo_camera_white" />
+                    android:src="@drawable/ic_photo_camera_white"
+                    app:layout_anchor="@id/problem_images_view_pager"
+                    app:layout_anchorGravity="bottom|right|end" />
             </FrameLayout>
 
             <LinearLayout


### PR DESCRIPTION
Reference: https://trello.com/c/dLHzELEw/168-bug-when-taking-pictures-in-the-updated-new-screen