### PR TITLE
When requesting permissions from fragment don't use ActivityCompat

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
@@ -11,7 +11,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.support.design.widget.TextInputLayout
-import android.support.v4.app.ActivityCompat.requestPermissions
 import android.support.v4.app.ActivityOptionsCompat
 import android.support.v4.content.ContextCompat.getColor
 import android.support.v7.app.AlertDialog
@@ -293,7 +292,7 @@ class NewReportFragment : BaseFragment(),
         if (PermissionUtils.isAllPermissionsGranted(activity, TAKE_PHOTO_PERMISSIONS)) {
             openPhotoSelectorDialog()
         } else {
-            requestPermissions(activity, TAKE_PHOTO_PERMISSIONS, TAKE_PHOTO_PERMISSIONS_REQUEST_CODE)
+            requestPermissions(TAKE_PHOTO_PERMISSIONS, TAKE_PHOTO_PERMISSIONS_REQUEST_CODE)
         }
     }
 
@@ -337,7 +336,7 @@ class NewReportFragment : BaseFragment(),
                 Toast.makeText(context, R.string.error_need_camera_and_storage_permission, Toast.LENGTH_SHORT).show()
             }
             MAP_PERMISSION_REQUEST_CODE -> if (PermissionUtils.isAllPermissionsGranted(activity, MAP_PERMISSIONS)) {
-                showPlacePicker(activity.currentFocus)
+                showPlacePicker(view!!)
             } else {
                 Toast.makeText(context, R.string.error_need_location_permission, Toast.LENGTH_SHORT).show()
             }
@@ -425,6 +424,7 @@ class NewReportFragment : BaseFragment(),
                         report_problem_location.setText(address)
                     }
                 }
+
             }
         }
     }
@@ -452,7 +452,7 @@ class NewReportFragment : BaseFragment(),
         if (PermissionUtils.isAllPermissionsGranted(activity, MAP_PERMISSIONS)) {
             showPlacePicker(view)
         } else {
-            requestPermissions(activity, MAP_PERMISSIONS, MAP_PERMISSION_REQUEST_CODE)
+            requestPermissions(MAP_PERMISSIONS, MAP_PERMISSION_REQUEST_CODE)
         }
     }
 


### PR DESCRIPTION
Result was returned to activity instead of fragment.

Reference: https://trello.com/c/EAYd63Qw/169-bug-user-must-repeat-action-after-permissions-granted