### PR TITLE
Separate my problems preferences and other preferences

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/BaseActivity.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/BaseActivity.java
@@ -6,17 +6,21 @@ import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import icepick.Icepick;
 import lt.vilnius.tvarkau.analytics.Analytics;
 import lt.vilnius.tvarkau.backend.LegacyApiService;
 import lt.vilnius.tvarkau.dagger.component.ApplicationComponent;
 
+import static lt.vilnius.tvarkau.prefs.Preferences.MY_PROBLEMS_PREFERENCES;
+
 public abstract class BaseActivity extends AppCompatActivity {
 
     @Inject
     LegacyApiService legacyApiService;
     @Inject
+    @Named(MY_PROBLEMS_PREFERENCES)
     SharedPreferences myProblemsPreferences;
     @Inject
     Analytics analytics;

--- a/app/src/main/java/lt/vilnius/tvarkau/dagger/module/SharedPreferencesModule.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/dagger/module/SharedPreferencesModule.kt
@@ -9,6 +9,7 @@ import lt.vilnius.tvarkau.prefs.BooleanPreference
 import lt.vilnius.tvarkau.prefs.BooleanPreferenceImpl
 import lt.vilnius.tvarkau.prefs.Preferences.DISPLAY_PHOTO_INSTRUCTIONS
 import lt.vilnius.tvarkau.prefs.Preferences.MY_PROBLEMS_PREFERENCES
+import lt.vilnius.tvarkau.prefs.Preferences.PREFS_NAME
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -17,7 +18,15 @@ class SharedPreferencesModule {
 
     @Provides
     @Singleton
-    internal fun providesSharedPreferences(application: Application): SharedPreferences {
+    @Named(PREFS_NAME)
+    fun providerApplicationPreferences(application: Application): SharedPreferences {
+        return application.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    @Provides
+    @Singleton
+    @Named(MY_PROBLEMS_PREFERENCES)
+    fun provideMyProblemPreferences(application: Application): SharedPreferences {
         return application.getSharedPreferences(MY_PROBLEMS_PREFERENCES, Context.MODE_PRIVATE)
     }
 
@@ -25,7 +34,7 @@ class SharedPreferencesModule {
     @Singleton
     @Named(DISPLAY_PHOTO_INSTRUCTIONS)
     fun providePhotoInstructions(
-            preference: SharedPreferences
+            @Named(PREFS_NAME) preference: SharedPreferences
     ): BooleanPreference {
         return BooleanPreferenceImpl(preference, DISPLAY_PHOTO_INSTRUCTIONS, true)
     }

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseFragment.kt
@@ -9,8 +9,10 @@ import lt.vilnius.tvarkau.backend.LegacyApiService
 import lt.vilnius.tvarkau.dagger.component.ApplicationComponent
 import lt.vilnius.tvarkau.dagger.module.IoScheduler
 import lt.vilnius.tvarkau.dagger.module.UiScheduler
+import lt.vilnius.tvarkau.prefs.Preferences
 import rx.Scheduler
 import javax.inject.Inject
+import javax.inject.Named
 
 /**
  * @author Martynas Jurkus
@@ -19,7 +21,7 @@ abstract class BaseFragment : Fragment() {
 
     @Inject
     lateinit var legacyApiService: LegacyApiService
-    @Inject
+    @field:[Inject Named(Preferences.MY_PROBLEMS_PREFERENCES)]
     lateinit var myProblemsPreferences: SharedPreferences
     @Inject
     lateinit var analytics: Analytics

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/ReportImportDialogFragment.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/ReportImportDialogFragment.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -40,6 +41,7 @@ import lt.vilnius.tvarkau.backend.LegacyApiService;
 import lt.vilnius.tvarkau.entity.LoginResponse;
 import lt.vilnius.tvarkau.entity.Problem;
 import lt.vilnius.tvarkau.events_listeners.NewProblemAddedEvent;
+import lt.vilnius.tvarkau.prefs.Preferences;
 import lt.vilnius.tvarkau.utils.EncryptUtils;
 import lt.vilnius.tvarkau.utils.FormatUtils;
 import lt.vilnius.tvarkau.utils.KeyboardUtils;
@@ -53,8 +55,10 @@ import timber.log.Timber;
 public class ReportImportDialogFragment extends DialogFragment {
 
     @Inject LegacyApiService legacyApiService;
-    @Inject SharedPreferences myProblemsPreferences;
     @Inject Analytics analytics;
+    @Inject
+    @Named(Preferences.MY_PROBLEMS_PREFERENCES)
+    SharedPreferences myProblemsPreferences;
 
     @BindView(R.id.vilnius_account_email)
     EditText vilniusAccountEmail;

--- a/app/src/main/java/lt/vilnius/tvarkau/prefs/Preferences.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/prefs/Preferences.kt
@@ -5,6 +5,7 @@ package lt.vilnius.tvarkau.prefs
  */
 object Preferences {
 
+    const val PREFS_NAME = "TVARKAU-VILNIU_PREFS"
     const val MY_PROBLEMS_PREFERENCES = "my_problem_preferences"
     const val DISPLAY_PHOTO_INSTRUCTIONS = "display_photo_instructions"
 }

--- a/app/src/main/java/lt/vilnius/tvarkau/utils/SharedPrefsManager.java
+++ b/app/src/main/java/lt/vilnius/tvarkau/utils/SharedPrefsManager.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import lt.vilnius.tvarkau.entity.Profile;
+import lt.vilnius.tvarkau.prefs.Preferences;
 import timber.log.Timber;
 
 /**
@@ -16,7 +17,6 @@ import timber.log.Timber;
  * but later on it also will help us to store actual user information.
  */
 public class SharedPrefsManager {
-    private static final String PREFS_NAME = "TVARKAU-VILNIU_PREFS";
 
     private static final String PREF_USER_PROFILE = "UserProfile";
     private static final String PREF_USER_ANONYMOUS = "UserAnonymous";
@@ -32,7 +32,7 @@ public class SharedPrefsManager {
 
 
     private SharedPrefsManager(Context context) {
-        sharedPreferences = context.getApplicationContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        sharedPreferences = context.getApplicationContext().getSharedPreferences(Preferences.PREFS_NAME, Context.MODE_PRIVATE);
     }
 
     private static void initializeInstance(Context context) {

--- a/app/src/test/java/lt/vilnius/tvarkau/dagger/component/TestApplicationComponent.java
+++ b/app/src/test/java/lt/vilnius/tvarkau/dagger/component/TestApplicationComponent.java
@@ -5,10 +5,10 @@ import javax.inject.Singleton;
 import dagger.Component;
 import lt.vilnius.tvarkau.TestActivity;
 import lt.vilnius.tvarkau.dagger.module.APIModule;
-import lt.vilnius.tvarkau.dagger.module.SharedPreferencesModule;
 import lt.vilnius.tvarkau.dagger.module.TestAnalyticsModule;
 import lt.vilnius.tvarkau.dagger.module.TestAppModule;
 import lt.vilnius.tvarkau.dagger.module.TestLegacyApiModule;
+import lt.vilnius.tvarkau.dagger.module.TestSharedPreferencesModule;
 import lt.vilnius.tvarkau.fragments.NewReportFragmentTest;
 import lt.vilnius.tvarkau.fragments.ProblemDetailFragmentTest;
 
@@ -21,7 +21,7 @@ import lt.vilnius.tvarkau.fragments.ProblemDetailFragmentTest;
         modules = {
                 TestLegacyApiModule.class,
                 APIModule.class,
-                SharedPreferencesModule.class,
+                TestSharedPreferencesModule.class,
                 TestAppModule.class,
                 TestAnalyticsModule.class
         }

--- a/app/src/test/java/lt/vilnius/tvarkau/dagger/module/TestSharedPreferencesModule.kt
+++ b/app/src/test/java/lt/vilnius/tvarkau/dagger/module/TestSharedPreferencesModule.kt
@@ -7,17 +7,26 @@ import com.nhaarman.mockito_kotlin.mock
 import dagger.Module
 import dagger.Provides
 import lt.vilnius.tvarkau.prefs.BooleanPreference
+import lt.vilnius.tvarkau.prefs.Preferences
 import lt.vilnius.tvarkau.prefs.Preferences.DISPLAY_PHOTO_INSTRUCTIONS
 import lt.vilnius.tvarkau.prefs.Preferences.MY_PROBLEMS_PREFERENCES
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
-class SharedPreferencesModule {
+class TestSharedPreferencesModule {
 
     @Provides
     @Singleton
-    internal fun providesSharedPreferences(application: Application): SharedPreferences {
+    @Named(Preferences.PREFS_NAME)
+    fun providerApplicationPreferences(application: Application): SharedPreferences {
+        return application.getSharedPreferences(Preferences.PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    @Provides
+    @Singleton
+    @Named(MY_PROBLEMS_PREFERENCES)
+    fun provideMyProblemPreferences(application: Application): SharedPreferences {
         return application.getSharedPreferences(MY_PROBLEMS_PREFERENCES, Context.MODE_PRIVATE)
     }
 


### PR DESCRIPTION
Forgot to separate preferences in initial implementation.

Issue was that "My problem list" screen tries to load ALL keys from preferences and expects string there.
But boolean got mixed in.

Reference: https://trello.com/c/qZ6mp0Ua/172-bug-the-app-crashes-after-right-after-sending-a-report-from-illegal-parking-category