### PR TITLE
Ensure keyboard is closed before opening photo selector dialog

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
@@ -330,6 +330,8 @@ class NewReportFragment : BaseFragment(),
     }
 
     private fun openPhotoSelectorDialog(displayPhotoInstructions: Boolean) {
+        activity.currentFocus?.let { KeyboardUtils.closeSoftKeyboard(activity, it) }
+
         if (displayPhotoInstructions) {
             arguments.putBoolean(KEY_TAKE_PHOTO, true)
             (activity as ReportRegistrationActivity).displayPhotoInstructions()


### PR DESCRIPTION
https://trello.com/c/MyqodE3E/178-hide-keyboard-on-screen-with-photo-instructions