### PR TITLE
Reenable proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
-//            shrinkResources true
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,6 +16,11 @@
 #   public *;
 #}
 
+
+# Disable obfuscation
+-dontobfuscate
+-optimizations !code/allocation/variable
+
 # Icepick
 -dontwarn icepick.**
 -keep class **$$Icepick { *; }


### PR DESCRIPTION
Issue https://trello.com/c/EDbQ0Gyg/98-fix-proguard-errors-with-minifyenabled-true
As @mjurkus suggested disabled obfuscation. It seems to be working correctly with proguard enabled.
APK size dropped from **4.73 MB** to **3.31 MB**. Method  count from **59 798** to **32 599**.

# Some statistics
## Version with Proguard
<img width="972" alt="screen shot 2017-02-11 at 11 41 53" src="https://cloud.githubusercontent.com/assets/3719141/22852875/38d96628-f04f-11e6-8d5c-3ccd69feebb2.png">

## Version without Proguard
<img width="968" alt="screen shot 2017-02-11 at 11 42 38" src="https://cloud.githubusercontent.com/assets/3719141/22852876/40f7c69c-f04f-11e6-9ab2-76c8fad4a6ac.png">
