### PR TITLE
Proguard and parceler

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -96,3 +96,9 @@
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
     rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }
+
+# Parceler
+-keep interface org.parceler.Parcel
+-keep @org.parceler.Parcel class * { *; }
+-keep class **$$Parcelable { *; }
+-keep class org.parceler.Parceler$$Parcels


### PR DESCRIPTION
Parceler rule for Proguard was missing. Regression from https://github.com/vilnius/tvarkau-vilniu/pull/172