### PR TITLE
Remove unneeded space from report description template

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,7 +157,7 @@
     <string name="add">Pridėti</string>
     <string name="personal_data_added">Jūsų duomenys pridėti</string>
     <string name="personal_data_sharing_enabled">Pridėjimas įjungtas</string>
-    <string name="report_description_timestamp_template" formatted="false">%s\nPažeidimo data ir laikas: %s \n Automobilio valst. nr: %s</string>
+    <string name="report_description_timestamp_template" formatted="false">%s\nPažeidimo data ir laikas: %s \nAutomobilio valst. nr: %s</string>
     <string name="photo_instructions_title">Padarykite mažiausiai dvi nuotraukas</string>
     <string name="photo_instructions_first_photo_hint">Nuotrauka, kurioje aiškiai matosi automobilis ir kelio ženklas ar kelio ženklinimas, draudžiantis stovėjimą</string>
     <string name="photo_instructions_second_photo_hint">Nuotrauka, kurioje iš arti matomas automobilio numeris ir ar yra (nėra) palikta neįgaliųjų asmenų automobilių statymo kortelė</string>


### PR DESCRIPTION
https://trello.com/c/ZNNS1PXQ/180-replace-the-white-space-in-template-from-the-front-of-automobilio-valst-nr-to-the-end-of-time

Screenshot of the problem:
![image](https://cloud.githubusercontent.com/assets/427661/23661674/0e919498-0356-11e7-9052-999f8aa314e6.png)
