### PR TITLE
Make address lookup more error prone

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
@@ -453,12 +453,11 @@ class NewReportFragment : BaseFragment(),
                         }
                     }
 
-                    if (addresses.isNotEmpty()) {
-                        if (addresses.first().locality != null) {
-                            val address = addresses.first().getAddressLine(0)
-                            report_problem_location_wrapper.error = null
-                            report_problem_location.setText(address)
-                        }
+                    val firstAddress = addresses.firstOrNull()
+                    if (firstAddress?.locality != null) {
+                        val address = firstAddress.getAddressLine(0)
+                        report_problem_location_wrapper.error = null
+                        report_problem_location.setText(address)
                     } else {
                         // Mostly when Geocoder throws IOException
                         // backup solution which in not 100% reliable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="empty_state_all_reports_line_1">Rezultatų nerasta</string>
     <string name="empty_state_all_reports_line_2">Pabandykite kitus paieškos kriterijus</string>
 
+    <string name="error_failed_to_determine_address">Nepavyko nustatyti adreso</string>
+
     <string name="error_empty_field">Tuščias laukelis</string>
     <string name="error_email_incorrect">Blogas el. pašto adresas</string>
     <string name="error_phone_number_incorrect">Blogas telefono numeris</string>


### PR DESCRIPTION
In some cases `Geocoder` fails to return address.

Fallbacking to latitude/longitude for address if address line is empty.