### PR TITLE
Show images indicator for correct image files number

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
@@ -320,9 +320,9 @@ class NewReportFragment : BaseFragment(),
 
         problem_images_view_pager.adapter.notifyDataSetChanged()
 
-        if (imageFiles.size > 1) {
+        if (this.imageFiles.size > 1) {
             problem_images_view_pager_indicator.visible()
-            problem_images_view_pager.currentItem = imageFiles.size - 1
+            problem_images_view_pager.currentItem = this.imageFiles.lastIndex
         }
     }
 


### PR DESCRIPTION
See https://trello.com/c/86YQahsJ/184-show-white-circles-for-pagination-when-several-pictures-taken-in-new-report-screen-like-in-view-report