### PR TITLE
Merged Bluetooth permission removal

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     compile "com.facebook.stetho:stetho:$stethoVersion"
     compile "com.facebook.stetho:stetho-okhttp3:$stethoVersion"
 
-    compile "com.mixpanel.android:mixpanel-android:4.9.7"
+    compile "com.mixpanel.android:mixpanel-android:4.9.8"
 
     compile "com.squareup.okhttp3:okhttp:$okhttpVersion"
     compile "com.squareup.okhttp3:logging-interceptor:$okhttpVersion"


### PR DESCRIPTION
Bluetooth permission was merged from MixPanel AndroidManifest file. Upgrading to newest version which has fix for this https://github.com/mixpanel/mixpanel-android/releases/tag/v4.9.8