### PR TITLE
Use single interface to describe app preferences

### DIFF
--- a/app/src/main/java/lt/vilnius/tvarkau/dagger/module/DataModule.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/dagger/module/DataModule.kt
@@ -9,10 +9,8 @@ import lt.vilnius.tvarkau.fragments.interactors.MultipleReportsMapInteractor
 import lt.vilnius.tvarkau.fragments.interactors.MultipleReportsMapInteractorImpl
 import lt.vilnius.tvarkau.mvp.interactors.ReportTypesInteractor
 import lt.vilnius.tvarkau.mvp.interactors.ReportTypesInteractorImpl
-import lt.vilnius.tvarkau.prefs.Preferences
-import lt.vilnius.tvarkau.prefs.StringPreference
+import lt.vilnius.tvarkau.prefs.AppPreferences
 import rx.Scheduler
-import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -36,14 +34,13 @@ class DataModule {
             api: LegacyApiService,
             context: Application,
             @IoScheduler ioScheduler: Scheduler,
-            @Named(Preferences.SELECTED_FILTER_REPORT_TYPE) reportType: StringPreference,
-            @Named(Preferences.SELECTED_FILTER_REPORT_STATUS) reportStatus: StringPreference
+            appPreferences: AppPreferences
     ): MultipleReportsMapInteractor {
         return MultipleReportsMapInteractorImpl(
                 api,
                 ioScheduler,
-                reportType,
-                reportStatus,
+                appPreferences.reportTypeSelectedFilter,
+                appPreferences.reportStatusSelectedFilter,
                 context.getString(R.string.report_filter_all_report_types)
         )
     }

--- a/app/src/main/java/lt/vilnius/tvarkau/dagger/module/SharedPreferencesModule.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/dagger/module/SharedPreferencesModule.kt
@@ -5,17 +5,10 @@ import android.content.Context
 import android.content.SharedPreferences
 import dagger.Module
 import dagger.Provides
-import lt.vilnius.tvarkau.prefs.LongPreference
-import lt.vilnius.tvarkau.prefs.LongPreferenceImpl
+import lt.vilnius.tvarkau.prefs.AppPreferences
+import lt.vilnius.tvarkau.prefs.AppPreferencesImpl
 import lt.vilnius.tvarkau.prefs.Preferences.COMMON_PREFERENCES
-import lt.vilnius.tvarkau.prefs.Preferences.LAST_DISPLAYED_PHOTO_INSTRUCTIONS
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_TYPE
 import lt.vilnius.tvarkau.prefs.Preferences.MY_PROBLEMS_PREFERENCES
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_TYPE
-import lt.vilnius.tvarkau.prefs.StringPreference
-import lt.vilnius.tvarkau.prefs.StringPreferenceImpl
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -38,46 +31,9 @@ class SharedPreferencesModule {
 
     @Provides
     @Singleton
-    @Named(LAST_DISPLAYED_PHOTO_INSTRUCTIONS)
-    fun providePhotoInstructions(
+    fun provideAppPreferences(
             @Named(COMMON_PREFERENCES) preference: SharedPreferences
-    ): LongPreference {
-        return LongPreferenceImpl(preference, LAST_DISPLAYED_PHOTO_INSTRUCTIONS, 0L)
-    }
-
-    @Provides
-    @Singleton
-    @Named(SELECTED_FILTER_REPORT_STATUS)
-    fun provideReportStatusFilter(
-            @Named(COMMON_PREFERENCES) preference: SharedPreferences
-    ): StringPreference {
-        return StringPreferenceImpl(preference, SELECTED_FILTER_REPORT_STATUS, "")
-    }
-
-    @Provides
-    @Singleton
-    @Named(SELECTED_FILTER_REPORT_TYPE)
-    fun provideReportTypeFilter(
-            @Named(COMMON_PREFERENCES) preference: SharedPreferences
-    ): StringPreference {
-        return StringPreferenceImpl(preference, SELECTED_FILTER_REPORT_TYPE, "")
-    }
-
-    @Provides
-    @Singleton
-    @Named(LIST_SELECTED_FILTER_REPORT_STATUS)
-    fun provideReportListStatusFilter(
-            @Named(COMMON_PREFERENCES) preference: SharedPreferences
-    ): StringPreference {
-        return StringPreferenceImpl(preference, LIST_SELECTED_FILTER_REPORT_STATUS, "")
-    }
-
-    @Provides
-    @Singleton
-    @Named(LIST_SELECTED_FILTER_REPORT_TYPE)
-    fun provideReportListTypeFilter(
-            @Named(COMMON_PREFERENCES) preference: SharedPreferences
-    ): StringPreference {
-        return StringPreferenceImpl(preference, LIST_SELECTED_FILTER_REPORT_TYPE, "")
+    ): AppPreferences {
+        return AppPreferencesImpl(preference)
     }
 }

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/AllReportsListFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/AllReportsListFragment.kt
@@ -15,11 +15,7 @@ import lt.vilnius.tvarkau.fragments.interactors.AllReportListInteractor
 import lt.vilnius.tvarkau.fragments.presenters.AllReportsListPresenterImpl
 import lt.vilnius.tvarkau.fragments.presenters.ProblemListPresenter
 import lt.vilnius.tvarkau.fragments.views.ReportListView
-import lt.vilnius.tvarkau.prefs.Preferences
-import lt.vilnius.tvarkau.prefs.StringPreference
 import lt.vilnius.tvarkau.widgets.EndlessScrollListener
-import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * @author Martynas Jurkus
@@ -28,11 +24,6 @@ import javax.inject.Named
         trackingScreenName = ActivityConstants.SCREEN_ALL_REPORTS_LIST)
 class AllReportsListFragment : BaseReportListFragment(), ReportListView {
 
-    @field:[Inject Named(Preferences.LIST_SELECTED_FILTER_REPORT_STATUS)]
-    lateinit var reportStatus: StringPreference
-    @field:[Inject Named(Preferences.LIST_SELECTED_FILTER_REPORT_TYPE)]
-    lateinit var reportType: StringPreference
-
     private lateinit var scrollListener: EndlessScrollListener
 
     override val presenter: ProblemListPresenter by lazy {
@@ -40,8 +31,8 @@ class AllReportsListFragment : BaseReportListFragment(), ReportListView {
                 AllReportListInteractor(
                         legacyApiService,
                         ioScheduler,
-                        reportType,
-                        reportStatus,
+                        appPreferences.reportTypeSelectedListFilter,
+                        appPreferences.reportStatusSelectedListFilter,
                         getString(R.string.report_filter_all_report_types)
                 ),
                 uiScheduler,

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/BaseFragment.kt
@@ -17,6 +17,7 @@ import lt.vilnius.tvarkau.extensions.emptyToNull
 import lt.vilnius.tvarkau.fragments.presenters.ConnectivityProvider
 import lt.vilnius.tvarkau.interfaces.OnBackPressed
 import lt.vilnius.tvarkau.navigation.NavigationManager
+import lt.vilnius.tvarkau.prefs.AppPreferences
 import lt.vilnius.tvarkau.prefs.Preferences
 import rx.Scheduler
 import javax.inject.Inject
@@ -35,6 +36,8 @@ abstract class BaseFragment : Fragment(), OnBackPressed {
     lateinit var legacyApiService: LegacyApiService
     @field:[Inject Named(Preferences.MY_PROBLEMS_PREFERENCES)]
     lateinit var myProblemsPreferences: SharedPreferences
+    @Inject
+    lateinit var appPreferences: AppPreferences
     @Inject
     lateinit var analytics: Analytics
     @Inject

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/NewReportFragment.kt
@@ -38,8 +38,6 @@ import lt.vilnius.tvarkau.mvp.presenters.NewReportData
 import lt.vilnius.tvarkau.mvp.presenters.NewReportPresenter
 import lt.vilnius.tvarkau.mvp.presenters.NewReportPresenterImpl
 import lt.vilnius.tvarkau.mvp.views.NewReportView
-import lt.vilnius.tvarkau.prefs.LongPreference
-import lt.vilnius.tvarkau.prefs.Preferences
 import lt.vilnius.tvarkau.rx.RxBus
 import lt.vilnius.tvarkau.utils.*
 import lt.vilnius.tvarkau.utils.FormatUtils.formatLocalDateTime
@@ -53,8 +51,6 @@ import timber.log.Timber
 import java.io.File
 import java.util.*
 import java.util.Calendar.*
-import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * @author Martynas Jurkus
@@ -64,9 +60,6 @@ import javax.inject.Named
 class NewReportFragment : BaseFragment(),
         NewProblemPhotosPagerAdapter.OnPhotoClickedListener,
         NewReportView {
-
-    @field:[Inject Named(Preferences.LAST_DISPLAYED_PHOTO_INSTRUCTIONS)]
-    lateinit var lastDisplayedPhotoInstructions: LongPreference
 
     private var googlePlayServicesResolutionDialog: Dialog? = null
 
@@ -99,7 +92,7 @@ class NewReportFragment : BaseFragment(),
 
     private val shouldDisplayPhotoInstructions: Boolean
         get() {
-            val delta = System.currentTimeMillis() - lastDisplayedPhotoInstructions.get()
+            val delta = System.currentTimeMillis() - appPreferences.photoInstructionsLastSeen.get()
             return reportType == PARKING_VIOLATIONS && Duration.ofMillis(delta).toDays() >= 1
         }
 

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/PhotoInstructionsFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/PhotoInstructionsFragment.kt
@@ -8,10 +8,6 @@ import kotlinx.android.synthetic.main.fragment_photo_instructions.*
 import lt.vilnius.tvarkau.R
 import lt.vilnius.tvarkau.activity.ActivityConstants
 import lt.vilnius.tvarkau.dagger.component.ActivityComponent
-import lt.vilnius.tvarkau.prefs.LongPreference
-import lt.vilnius.tvarkau.prefs.Preferences.LAST_DISPLAYED_PHOTO_INSTRUCTIONS
-import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * @author Martynas Jurkus
@@ -19,9 +15,6 @@ import javax.inject.Named
 @Screen(navigationMode = NavigationMode.CLOSE,
         trackingScreenName = ActivityConstants.SCREEN_PHOTO_INSTRUCTIONS)
 class PhotoInstructionsFragment : BaseFragment() {
-
-    @field:[Inject Named(LAST_DISPLAYED_PHOTO_INSTRUCTIONS)]
-    lateinit var lastDisplayPhotoInstructions: LongPreference
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_photo_instructions, container, false)
@@ -36,7 +29,7 @@ class PhotoInstructionsFragment : BaseFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        lastDisplayPhotoInstructions.set(System.currentTimeMillis())
+        appPreferences.photoInstructionsLastSeen.set(System.currentTimeMillis())
     }
 
     override fun onInject(component: ActivityComponent) {

--- a/app/src/main/java/lt/vilnius/tvarkau/fragments/ReportFilterFragment.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/fragments/ReportFilterFragment.kt
@@ -12,15 +12,9 @@ import lt.vilnius.tvarkau.entity.Problem.Companion.STATUS_REGISTERED
 import lt.vilnius.tvarkau.events_listeners.RefreshReportFilterEvent
 import lt.vilnius.tvarkau.extensions.emptyToNull
 import lt.vilnius.tvarkau.mvp.interactors.ReportTypesInteractor
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_TYPE
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_TYPE
-import lt.vilnius.tvarkau.prefs.StringPreference
 import lt.vilnius.tvarkau.rx.RxBus
 import lt.vilnius.tvarkau.views.adapters.FilterReportTypesAdapter
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * @author Martynas Jurkus
@@ -32,14 +26,6 @@ class ReportFilterFragment : BaseFragment() {
 
     @Inject
     lateinit var reportTypesInteractor: ReportTypesInteractor
-    @field:[Inject Named(SELECTED_FILTER_REPORT_STATUS)]
-    lateinit var mapReportStatusFilter: StringPreference
-    @field:[Inject Named(SELECTED_FILTER_REPORT_TYPE)]
-    lateinit var mapReportTypeFilter: StringPreference
-    @field:[Inject Named(LIST_SELECTED_FILTER_REPORT_STATUS)]
-    lateinit var listReportStatusFilter: StringPreference
-    @field:[Inject Named(LIST_SELECTED_FILTER_REPORT_TYPE)]
-    lateinit var listReportTypeFilter: StringPreference
 
     private lateinit var adapter: FilterReportTypesAdapter
 
@@ -135,9 +121,9 @@ class ReportFilterFragment : BaseFragment() {
 
     private fun getSelectedReportType(): String {
         val selected = if (isMapTarget) {
-            mapReportTypeFilter.get()
+            appPreferences.reportTypeSelectedFilter.get()
         } else {
-            listReportTypeFilter.get()
+            appPreferences.reportTypeSelectedListFilter.get()
         }
 
         return selected.emptyToNull() ?: allReportTypesLabel
@@ -145,9 +131,9 @@ class ReportFilterFragment : BaseFragment() {
 
     private fun getSelectedReportStatus(): String {
         return if (isMapTarget) {
-            mapReportStatusFilter.get()
+            appPreferences.reportStatusSelectedListFilter.get()
         } else {
-            listReportStatusFilter.get()
+            appPreferences.reportStatusSelectedListFilter.get()
         }
     }
 
@@ -158,15 +144,14 @@ class ReportFilterFragment : BaseFragment() {
                 filter_report_status_completed
         ).find { it?.isSelected ?: false }?.tag as? String
 
-        val targetName: String
-        if (isMapTarget) {
-            mapReportStatusFilter.set(selectedState.orEmpty())
-            mapReportTypeFilter.set(adapter.selected)
-            targetName = "map"
+        val targetName = if (isMapTarget) {
+            appPreferences.reportStatusSelectedListFilter.set(selectedState.orEmpty())
+            appPreferences.reportTypeSelectedFilter.set(adapter.selected)
+            "map"
         } else {
-            listReportStatusFilter.set(selectedState.orEmpty())
-            listReportTypeFilter.set(adapter.selected)
-            targetName = "list"
+            appPreferences.reportStatusSelectedListFilter.set(selectedState.orEmpty())
+            appPreferences.reportTypeSelectedListFilter.set(adapter.selected)
+            "list"
         }
 
         analytics.trackApplyReportFilter(selectedState.orEmpty(), adapter.selected, targetName)

--- a/app/src/main/java/lt/vilnius/tvarkau/prefs/AppPreferences.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/prefs/AppPreferences.kt
@@ -1,0 +1,15 @@
+package lt.vilnius.tvarkau.prefs
+
+
+interface AppPreferences {
+
+    val photoInstructionsLastSeen: LongPreference
+
+    val reportStatusSelectedFilter: StringPreference
+
+    val reportTypeSelectedFilter: StringPreference
+
+    val reportStatusSelectedListFilter: StringPreference
+
+    val reportTypeSelectedListFilter: StringPreference
+}

--- a/app/src/main/java/lt/vilnius/tvarkau/prefs/AppPreferencesImpl.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/prefs/AppPreferencesImpl.kt
@@ -1,0 +1,38 @@
+package lt.vilnius.tvarkau.prefs
+
+import android.content.SharedPreferences
+
+
+class AppPreferencesImpl(
+        private val preferences: SharedPreferences
+) : AppPreferences {
+
+    override val photoInstructionsLastSeen by lazy {
+        LongPreferenceImpl(preferences, LAST_DISPLAYED_PHOTO_INSTRUCTIONS, 0L)
+    }
+    override val reportStatusSelectedFilter by lazy {
+        StringPreferenceImpl(preferences, SELECTED_FILTER_REPORT_STATUS, "")
+    }
+
+    override val reportTypeSelectedFilter by lazy {
+        StringPreferenceImpl(preferences, SELECTED_FILTER_REPORT_TYPE, "")
+    }
+
+    override val reportStatusSelectedListFilter by lazy {
+        StringPreferenceImpl(preferences, LIST_SELECTED_FILTER_REPORT_STATUS, "")
+    }
+
+    override val reportTypeSelectedListFilter by lazy {
+        StringPreferenceImpl(preferences, LIST_SELECTED_FILTER_REPORT_TYPE, "")
+    }
+
+    companion object {
+        const val COMMON_PREFERENCES = "TVARKAU-VILNIU_PREFS"
+        const val MY_PROBLEMS_PREFERENCES = "my_problem_preferences"
+        const val SELECTED_FILTER_REPORT_STATUS = "filter_report_status"
+        const val SELECTED_FILTER_REPORT_TYPE = "filter_report_type"
+        const val LIST_SELECTED_FILTER_REPORT_STATUS = "list_filter_report_status"
+        const val LIST_SELECTED_FILTER_REPORT_TYPE = "list_filter_report_type"
+        const val LAST_DISPLAYED_PHOTO_INSTRUCTIONS = "last_displayed_photo_instructions"
+    }
+}

--- a/app/src/main/java/lt/vilnius/tvarkau/prefs/Preferences.kt
+++ b/app/src/main/java/lt/vilnius/tvarkau/prefs/Preferences.kt
@@ -7,9 +7,4 @@ object Preferences {
 
     const val COMMON_PREFERENCES = "TVARKAU-VILNIU_PREFS"
     const val MY_PROBLEMS_PREFERENCES = "my_problem_preferences"
-    const val SELECTED_FILTER_REPORT_STATUS = "filter_report_status"
-    const val SELECTED_FILTER_REPORT_TYPE = "filter_report_type"
-    const val LIST_SELECTED_FILTER_REPORT_STATUS = "list_filter_report_status"
-    const val LIST_SELECTED_FILTER_REPORT_TYPE = "list_filter_report_type"
-    const val LAST_DISPLAYED_PHOTO_INSTRUCTIONS = "last_displayed_photo_instructions"
 }

--- a/app/src/test/java/lt/vilnius/tvarkau/dagger/module/TestSharedPreferencesModule.kt
+++ b/app/src/test/java/lt/vilnius/tvarkau/dagger/module/TestSharedPreferencesModule.kt
@@ -6,14 +6,10 @@ import android.content.SharedPreferences
 import com.nhaarman.mockito_kotlin.mock
 import dagger.Module
 import dagger.Provides
+import lt.vilnius.tvarkau.prefs.AppPreferences
 import lt.vilnius.tvarkau.prefs.LongPreference
 import lt.vilnius.tvarkau.prefs.Preferences
-import lt.vilnius.tvarkau.prefs.Preferences.LAST_DISPLAYED_PHOTO_INSTRUCTIONS
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.LIST_SELECTED_FILTER_REPORT_TYPE
 import lt.vilnius.tvarkau.prefs.Preferences.MY_PROBLEMS_PREFERENCES
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_STATUS
-import lt.vilnius.tvarkau.prefs.Preferences.SELECTED_FILTER_REPORT_TYPE
 import lt.vilnius.tvarkau.prefs.StringPreference
 import javax.inject.Named
 import javax.inject.Singleton
@@ -37,27 +33,15 @@ class TestSharedPreferencesModule {
 
     @Provides
     @Singleton
-    @Named(LAST_DISPLAYED_PHOTO_INSTRUCTIONS)
-    fun providePhotoInstructions(): LongPreference = mock()
-
-
-    @Provides
-    @Singleton
-    @Named(SELECTED_FILTER_REPORT_STATUS)
-    fun provideReportStatusFilter(): StringPreference = mock()
-
-    @Provides
-    @Singleton
-    @Named(SELECTED_FILTER_REPORT_TYPE)
-    fun provideReportTypeFilter(): StringPreference = mock()
-
-    @Provides
-    @Singleton
-    @Named(LIST_SELECTED_FILTER_REPORT_STATUS)
-    fun provideReportListStatusFilter(): StringPreference = mock()
-
-    @Provides
-    @Singleton
-    @Named(LIST_SELECTED_FILTER_REPORT_TYPE)
-    fun provideReportListTypeFilter(): StringPreference = mock()
+    fun provideAppPreferences(
+            @Named(Preferences.COMMON_PREFERENCES) preference: SharedPreferences
+    ): AppPreferences {
+        return object : AppPreferences {
+            override val photoInstructionsLastSeen: LongPreference = mock()
+            override val reportStatusSelectedFilter: StringPreference = mock()
+            override val reportTypeSelectedFilter: StringPreference = mock()
+            override val reportStatusSelectedListFilter: StringPreference = mock()
+            override val reportTypeSelectedListFilter: StringPreference = mock()
+        }
+    }
 }


### PR DESCRIPTION
This makes preferences more understandable and maintainable.
- Reduces code duplication with removal of multiple inject locations
- Preferences are initialised only when they are accessed and not when injected 