### PR TITLE
Fix gradle being unable to resolve firebase-* dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven {
             url 'https://maven.fabric.io/public'
         }
@@ -17,8 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://clojars.org/repo/" }
         maven { url "https://jitpack.io" }
         mavenCentral()


### PR DESCRIPTION
I was unable to clean-build the gradle project, nor did it work for me with latest Android studio, before I applied this fix (google repo on top). I don't see how this could break anything. Besides, android docs suggest the same thing: https://developer.android.com/studio/build/#top-level